### PR TITLE
Feature branch update to dev

### DIFF
--- a/include/cmm/BinOpNode.h
+++ b/include/cmm/BinOpNode.h
@@ -111,6 +111,13 @@ namespace cmm
         const ExpressionNode* getRight() const CMM_NOEXCEPT;
 
         /**
+         * Attempts to cast the left ExpressionNode.
+         *
+         * @param newType the type of the sub-expression.
+         */
+        void castLeft(const CType& newType);
+
+        /**
          * Attempts to cast the right ExpressionNode.
          *
          * @param newType the type of the sub-expression.

--- a/include/cmm/Reporter.h
+++ b/include/cmm/Reporter.h
@@ -77,6 +77,15 @@ namespace cmm
         s32 getWarningCount() const CMM_NOEXCEPT;
 
         /**
+         * Sets whether the reporter actually prints something to std::cout.
+         * This is helpful for disabling in unit tests where we only care
+         * about error, warn, etc. counts.
+         *
+         * @param enable flag whether to enable/disable printing.
+         */
+        void setEnablePrint(const bool enable) CMM_NOEXCEPT;
+
+        /**
          * Reports a bug in the compiler.
          *
          * @param msg the templated error message to provide.
@@ -85,7 +94,10 @@ namespace cmm
         template<class T>
         void bug(const T& msg, const Location& location, const bool fatal)
         {
-            std::cout << "bug: " << msg << " at " << location << std::endl;
+            if (canPrint)
+            {
+                std::cout << "bug: " << msg << " at " << location << std::endl;
+            }
 
             if (fatal)
             {
@@ -102,7 +114,11 @@ namespace cmm
         template<class T>
         void error(const T& msg, const Location& location)
         {
-            std::cout << "error: " << msg << " at " << location << std::endl;
+            if (canPrint)
+            {
+                std::cout << "error: " << msg << " at " << location << std::endl;
+            }
+
             ++errors;
         }
 
@@ -115,7 +131,11 @@ namespace cmm
         template<class T>
         void warn(const T& msg, const Location& location)
         {
-            std::cout << "warning: " << msg << " at " << location << std::endl;
+            if (canPrint)
+            {
+                std::cout << "warning: " << msg << " at " << location << std::endl;
+            }
+
             ++warnings;
         }
 
@@ -131,6 +151,9 @@ namespace cmm
 
         // The count of warnings.
         s32 warnings;
+
+        // Flag for enabling/disabling printing.
+        bool canPrint;
     };
 }
 

--- a/include/cmm/visit/Analyzer.h
+++ b/include/cmm/visit/Analyzer.h
@@ -69,7 +69,10 @@ namespace cmm
          */
         Analyzer& operator= (Analyzer&&) CMM_NOEXCEPT = delete;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
         virtual VisitorResult visit(AddressOfNode& node) override;
+#pragma GCC diagnostic pop
         virtual VisitorResult visit(ArgNode& node) override;
         virtual VisitorResult visit(BinOpNode& node) override;
         virtual VisitorResult visit(BlockNode& node) override;

--- a/include/cmm/visit/Dump.h
+++ b/include/cmm/visit/Dump.h
@@ -51,7 +51,10 @@ namespace cmm
          */
         Dump& operator= (Dump&&) CMM_NOEXCEPT = delete;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
         virtual VisitorResult visit(AddressOfNode& node) override;
+#pragma GCC diagnostic pop
         virtual VisitorResult visit(ArgNode& node) override;
         virtual VisitorResult visit(BinOpNode& node) override;
         virtual VisitorResult visit(BlockNode& node) override;

--- a/include/cmm/visit/Visitor.h
+++ b/include/cmm/visit/Visitor.h
@@ -93,7 +93,10 @@ namespace cmm
          */
         Visitor& operator= (Visitor&&) CMM_NOEXCEPT = delete;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
         virtual VisitorResult visit(AddressOfNode& node) = 0;
+#pragma GCC diagnostic pop
         virtual VisitorResult visit(ArgNode& node) = 0;
         virtual VisitorResult visit(BinOpNode& node) = 0;
         virtual VisitorResult visit(BlockNode& node) = 0;

--- a/src/BinOpNode.cpp
+++ b/src/BinOpNode.cpp
@@ -67,6 +67,13 @@ namespace cmm
         return right.get();
     }
 
+    void BinOpNode::castLeft(const CType& newType)
+    {
+        const auto location = left->getLocation();
+        auto tempLeft = std::move(left);
+        left = std::make_unique<CastNode>(location, newType, std::move(tempLeft));
+    }
+
     void BinOpNode::castRight(const CType& newType)
     {
         const auto location = right->getLocation();

--- a/src/Reporter.cpp
+++ b/src/Reporter.cpp
@@ -10,20 +10,23 @@
 
 namespace cmm
 {
-    Reporter::Reporter() CMM_NOEXCEPT : errors(0), warnings(0)
+    Reporter::Reporter() CMM_NOEXCEPT : errors(0), warnings(0), canPrint(true)
     {
     }
 
     Reporter::~Reporter()
     {
-        if (errors > 0)
+        if (canPrint)
         {
-            std::cout << errors << " errors during compilation\n";
-        }
+            if (errors > 0)
+            {
+                std::cout << errors << " errors during compilation\n";
+            }
 
-        if (warnings > 0)
-        {
-            std::cout << warnings << " warnings during compilation\n";
+            if (warnings > 0)
+            {
+                std::cout << warnings << " warnings during compilation\n";
+            }
         }
     }
 
@@ -42,6 +45,11 @@ namespace cmm
     s32 Reporter::getWarningCount() const CMM_NOEXCEPT
     {
         return warnings;
+    }
+
+    void Reporter::setEnablePrint(const bool enable) CMM_NOEXCEPT
+    {
+        this->canPrint = enable;
     }
 
     void Reporter::reset()

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -87,6 +87,8 @@ namespace cmm
                 set.emplace(EnumCType::INT16);
                 set.emplace(EnumCType::INT32);
                 set.emplace(EnumCType::INT64);
+                set.emplace(EnumCType::FLOAT);
+                set.emplace(EnumCType::DOUBLE);
             }
 
             {
@@ -95,6 +97,8 @@ namespace cmm
                 set.emplace(EnumCType::INT16);
                 set.emplace(EnumCType::INT32);
                 set.emplace(EnumCType::INT64);
+                set.emplace(EnumCType::FLOAT);
+                set.emplace(EnumCType::DOUBLE);
             }
 
             {
@@ -102,17 +106,23 @@ namespace cmm
                 set.emplace(EnumCType::INT16);
                 set.emplace(EnumCType::INT32);
                 set.emplace(EnumCType::INT64);
+                set.emplace(EnumCType::FLOAT);
+                set.emplace(EnumCType::DOUBLE);
             }
 
             {
                 auto& set = promoMap[EnumCType::INT32];
                 set.emplace(EnumCType::INT32);
                 set.emplace(EnumCType::INT64);
+                set.emplace(EnumCType::FLOAT);
+                set.emplace(EnumCType::DOUBLE);
             }
 
             {
                 auto& set = promoMap[EnumCType::INT64];
                 set.emplace(EnumCType::INT64);
+                set.emplace(EnumCType::FLOAT);
+                set.emplace(EnumCType::DOUBLE);
             }
         }
 

--- a/src/visit/Analyzer.cpp
+++ b/src/visit/Analyzer.cpp
@@ -141,7 +141,6 @@ namespace cmm
             }
 
             // See if it's void pointer magic
-            // TODO: This may fail if this isn't assignment.
             else if ((leftType.type == EnumCType::VOID && leftType.pointers > 0 && rightType.pointers > 0) ||
                      (rightType.type == EnumCType::VOID && rightType.pointers > 0 && leftType.pointers > 0))
             {
@@ -674,9 +673,11 @@ namespace cmm
 
     VisitorResult Analyzer::visit(TypeNode& node)
     {
-        // TODO: What to do here??
+        // Note: Parser should have verified the type, however with some structs
+        // or typedefs, it may not have been able to fully verify and deferred to here.
+        // TODO: Update this logic once we get there.
         [[maybe_unused]]
-        const auto datatype = node.getDatatype();
+        const auto& datatype = node.getDatatype();
 
         return VisitorResult();
     }

--- a/src/visit/Analyzer.cpp
+++ b/src/visit/Analyzer.cpp
@@ -176,6 +176,18 @@ namespace cmm
             }
         }
 
+        else if (leftType.pointers > 0 && rightType.pointers > 0)
+        {
+            std::ostringstream builder;
+            builder << "Invalid operands to binary expression between '";
+            printType(builder, leftType);
+            builder << "' and '";
+            printType(builder, rightType);
+            builder << "'";
+
+            reporter.error(builder.str(), node.getLocation());
+        }
+
         return VisitorResult();
     }
 

--- a/src/visit/Analyzer.cpp
+++ b/src/visit/Analyzer.cpp
@@ -29,6 +29,8 @@ namespace cmm
         localityStack.push(EnumLocality::GLOBAL);
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
     VisitorResult Analyzer::visit(AddressOfNode& node)
     {
         auto* variablePtr = node.getExpression();
@@ -49,6 +51,7 @@ namespace cmm
 
         return VisitorResult();
     }
+#pragma GCC diagnostic pop
 
     VisitorResult Analyzer::visit(ArgNode& node)
     {

--- a/src/visit/Dump.cpp
+++ b/src/visit/Dump.cpp
@@ -25,6 +25,8 @@ namespace cmm
     {
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
     VisitorResult Dump::visit(AddressOfNode& node)
     {
         printIndentation();
@@ -40,6 +42,7 @@ namespace cmm
 
         return VisitorResult();
     }
+#pragma GCC diagnostic pop
 
     VisitorResult Dump::visit(ArgNode& node)
     {

--- a/test/AnalyzerTest.cpp
+++ b/test/AnalyzerTest.cpp
@@ -514,6 +514,42 @@ TEST(AnalyzerTest, AnalyzerImplicitCastFloatAddIntWarning)
     ASSERT_EQ(reporter.getErrorCount(), 0);
 }
 
+TEST(AnalyzerTest, AnalyzerImplicitCastIntPointerAddIntWarning)
+{
+    reporter.reset();
+
+    const std::string input = "int x; x = 5; int* xPtr; xPtr = &x; int* result; result = xPtr + 5;";
+    Parser parser(input);
+    std::string errorMessage;
+    auto compUnitPtr = parser.parseCompilationUnit(&errorMessage);
+
+    ASSERT_TRUE(errorMessage.empty());
+    ASSERT_NE(compUnitPtr, nullptr);
+
+    Analyzer analyzer;
+    analyzer.visit(*compUnitPtr);
+    ASSERT_EQ(reporter.getWarningCount(), 0);
+    ASSERT_GT(reporter.getErrorCount(), 1);
+}
+
+TEST(AnalyzerTest, AnalyzerImplicitCastIntPointerAddIntPointerError)
+{
+    reporter.reset();
+
+    const std::string input = "int x; x = 5; int y; y = 10; int* xPtr; xPtr = &x; int* yPtr; yPtr = &y; int* result; result = xPtr + yPtr;";
+    Parser parser(input);
+    std::string errorMessage;
+    auto compUnitPtr = parser.parseCompilationUnit(&errorMessage);
+
+    ASSERT_TRUE(errorMessage.empty());
+    ASSERT_NE(compUnitPtr, nullptr);
+
+    Analyzer analyzer;
+    analyzer.visit(*compUnitPtr);
+    ASSERT_EQ(reporter.getWarningCount(), 0);
+    ASSERT_GT(reporter.getErrorCount(), 0);
+}
+
 s32 main(s32 argc, char* argv[])
 {
     reporter.setEnablePrint(false);

--- a/test/AnalyzerTest.cpp
+++ b/test/AnalyzerTest.cpp
@@ -478,8 +478,45 @@ TEST(AnalyzerTest, AnalyzerImplicitCastDoubleVoidPtrAssignVoidPtrValid)
     ASSERT_EQ(reporter.getErrorCount(), 0);
 }
 
+TEST(AnalyzerTest, AnalyzerImplicitCastIntAddFloatWarning)
+{
+    reporter.reset();
+
+    const std::string input = "1 + 2.0F;";
+    Parser parser(input);
+    std::string errorMessage;
+    auto compUnitPtr = parser.parseCompilationUnit(&errorMessage);
+
+    ASSERT_TRUE(errorMessage.empty());
+    ASSERT_NE(compUnitPtr, nullptr);
+
+    Analyzer analyzer;
+    analyzer.visit(*compUnitPtr);
+    ASSERT_EQ(reporter.getWarningCount(), 1);
+    ASSERT_EQ(reporter.getErrorCount(), 0);
+}
+
+TEST(AnalyzerTest, AnalyzerImplicitCastFloatAddIntWarning)
+{
+    reporter.reset();
+
+    const std::string input = "1.0F + 2;";
+    Parser parser(input);
+    std::string errorMessage;
+    auto compUnitPtr = parser.parseCompilationUnit(&errorMessage);
+
+    ASSERT_TRUE(errorMessage.empty());
+    ASSERT_NE(compUnitPtr, nullptr);
+
+    Analyzer analyzer;
+    analyzer.visit(*compUnitPtr);
+    ASSERT_EQ(reporter.getWarningCount(), 1);
+    ASSERT_EQ(reporter.getErrorCount(), 0);
+}
+
 s32 main(s32 argc, char* argv[])
 {
+    reporter.setEnablePrint(false);
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/ParserTest.cpp
+++ b/test/ParserTest.cpp
@@ -1115,16 +1115,6 @@ TEST(ParserTest, ParseCompilationNodeVarAssignmentViaDerferencedNegativeVariable
 
     ASSERT_FALSE(errorMessage.empty());
     ASSERT_EQ(compUnitPtr, nullptr);
-
-    // TODO: @@@ fix
-    // auto& translationUnit = compUnitPtr->getRoot();
-    // auto& firstStatement = *translationUnit.begin();
-    // ASSERT_EQ(firstStatement->getType(), NodeType::EXPRESSION_STATEMENT);
-
-    // auto* expressionStatement = static_cast<ExpressionStatementNode*>(firstStatement.get());
-    // ASSERT_NE(expressionStatement->getExpression(), nullptr);
-    // ASSERT_EQ(expressionStatement->getExpression()->getType(), NodeType::BIN_OP);
-
     ASSERT_GT(reporter.getErrorCount(), 0);
 }
 
@@ -1177,6 +1167,7 @@ TEST(ParserTest, ParseCompilationNodeVarAssignmentViaAddressOfFuncCausesError)
 
     ASSERT_FALSE(errorMessage.empty());
     ASSERT_EQ(compUnitPtr, nullptr);
+    ASSERT_GT(reporter.getErrorCount(), 0);
 }
 
 TEST(ParserTest, ParseCompilationNodeVarAssignmentViaAddressOfIntError)
@@ -1188,6 +1179,7 @@ TEST(ParserTest, ParseCompilationNodeVarAssignmentViaAddressOfIntError)
 
     ASSERT_FALSE(errorMessage.empty());
     ASSERT_EQ(compUnitPtr, nullptr);
+    ASSERT_GT(reporter.getErrorCount(), 0);
 }
 
 TEST(ParserTest, ParseCompilationNodeVarDerefAssignmentViaAddressOfFuncCausesError)
@@ -1199,6 +1191,7 @@ TEST(ParserTest, ParseCompilationNodeVarDerefAssignmentViaAddressOfFuncCausesErr
 
     ASSERT_FALSE(errorMessage.empty());
     ASSERT_EQ(compUnitPtr, nullptr);
+    ASSERT_GT(reporter.getErrorCount(), 0);
 }
 
 TEST(ParserTest, ParseCompilationNodeVarAssignmentViaPointer)

--- a/test/ParserTest.cpp
+++ b/test/ParserTest.cpp
@@ -1116,6 +1116,7 @@ TEST(ParserTest, ParseCompilationNodeVarAssignmentViaDerferencedNegativeVariable
     ASSERT_FALSE(errorMessage.empty());
     ASSERT_EQ(compUnitPtr, nullptr);
 
+    // TODO: @@@ fix
     // auto& translationUnit = compUnitPtr->getRoot();
     // auto& firstStatement = *translationUnit.begin();
     // ASSERT_EQ(firstStatement->getType(), NodeType::EXPRESSION_STATEMENT);
@@ -3248,6 +3249,7 @@ TEST(ParserTest, ParseCompilationNodeUnaryIncrement)
 
 s32 main(s32 argc, char* argv[])
 {
+    reporter.setEnablePrint(false);
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
In brief, this PR contains:

- Fixed nested BinOpNode's datatype parsing incorrectly.
- Allow disabling/silencing the Reporter's warnings, errors, etc. while maintaining count of warnings, errors, etc. counts.  This is particularly useful for the Analyzer unit test where we don't necessarily care about the exact error, but rather whether an occurred or not.
- More CastNode tests and fixes along the way.