### PR TITLE
Resolve issue #76 - unnecessary castnode

### DIFF
--- a/include/cmm/CastNode.h
+++ b/include/cmm/CastNode.h
@@ -20,11 +20,6 @@
 
 namespace cmm
 {
-    enum class EnumCastType
-    {
-        NOP = 0, NARROWING, WIDENING
-    };
-
     class CastNode : public ExpressionNode
     {
     public:
@@ -101,6 +96,20 @@ namespace cmm
          */
         void derefNode();
 
+        /**
+         * Gets the EnumCastType of this CastNode.
+         *
+         * @return EnumCastType.
+         */
+        EnumCastType getCastType() const CMM_NOEXCEPT;
+
+        /**
+         * Sets the EnumCastType for this CastNode.
+         *
+         * @param castType the EnumCastType to set.
+         */
+        void setCastType(const EnumCastType castType) CMM_NOEXCEPT;
+
         VisitorResult accept(Visitor* visitor) override;
         std::string toString() const override;
 
@@ -108,6 +117,9 @@ namespace cmm
 
         // The expression we are casting.
         std::unique_ptr<ExpressionNode> expression;
+
+        // The type of cast.
+        EnumCastType castType;
     };
 }
 

--- a/include/cmm/Types.h
+++ b/include/cmm/Types.h
@@ -340,6 +340,13 @@ namespace cmm
 
     std::optional<EnumBinOpNodeType> isEnumBinOpType(const Token& token) CMM_NOEXCEPT;
 
+    enum class EnumCastType
+    {
+        NOP = 0, NARROWING, WIDENING
+    };
+
+    const char* toString(const EnumCastType type) CMM_NOEXCEPT;
+
     enum class EnumFieldAccessType
     {
         DOT = 0, ARROW

--- a/include/cmm/VariableNode.h
+++ b/include/cmm/VariableNode.h
@@ -82,6 +82,18 @@ namespace cmm
          */
         const std::string& getName() const CMM_NOEXCEPT;
 
+        /**
+         * Gets the EnumLocality of this variable.
+         *
+         * @return EnumLocality.
+         */
+        EnumLocality getLocality() const CMM_NOEXCEPT;
+
+        /**
+         * Set the EnumLocality of this variable.
+         */
+        void setLocality(const EnumLocality locality) CMM_NOEXCEPT;
+
         VisitorResult accept(Visitor* visitor) override;
         std::string toString() const override;
 
@@ -89,6 +101,9 @@ namespace cmm
 
         // The name of the variable.
         std::string name;
+
+        // The locality of the variable.
+        EnumLocality locality;
     };
 }
 

--- a/src/CastNode.cpp
+++ b/src/CastNode.cpp
@@ -43,6 +43,16 @@ namespace cmm
         expression = std::make_unique<DerefNode>(location, std::move(temp));
     }
 
+    EnumCastType CastNode::getCastType() const CMM_NOEXCEPT
+    {
+        return castType;
+    }
+
+    void CastNode::setCastType(const EnumCastType castType) CMM_NOEXCEPT
+    {
+        this->castType = castType;
+    }
+
     VisitorResult CastNode::accept(Visitor* visitor) /* override */
     {
         return visitor->visit(*this);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -24,7 +24,8 @@ int main()
     // std::string input = "struct Vec2 { int x; int y; }; int main() { struct Vec2 v2; v2.x = 10; v2.y = 32; int result; result = v2.x + v2.y; return result; }";
     // std::string input = "struct Vec2 { int x; int y; }; struct Vec3 { struct Vec2 v2; int z; }; int main() { struct Vec3 v3; v3.v2.x = 10; v3.v2.y = 12; v3.z = 20; int result; result = v3.v2.x + v3.v2.y + v3.z; return result; }";
     // std::string input = "enum A { X, Y }; int main() { int z; z = (int) Y; return z; }";
-    std::string input = "enum A { X, Y }; int main() { enum A a; a = Y; return (int) a; }";
+    // std::string input = "enum A { X, Y }; int main() { enum A a; a = Y; return (int) a; }";
+    std::string input = "int main() { int z; z = (int) 5; return z; }";
     std::string errorMessage;
     Parser parser(input);
     auto compUnitPtr = parser.parseCompilationUnit(&errorMessage);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -25,7 +25,8 @@ int main()
     // std::string input = "struct Vec2 { int x; int y; }; struct Vec3 { struct Vec2 v2; int z; }; int main() { struct Vec3 v3; v3.v2.x = 10; v3.v2.y = 12; v3.z = 20; int result; result = v3.v2.x + v3.v2.y + v3.z; return result; }";
     // std::string input = "enum A { X, Y }; int main() { int z; z = (int) Y; return z; }";
     // std::string input = "enum A { X, Y }; int main() { enum A a; a = Y; return (int) a; }";
-    std::string input = "int main() { int z; z = (int) 5; return z; }";
+    // std::string input = "int func(char c) { int z; z = (int) c; return z; } double func2(float f) { double z; z = (double) f; return z; } float func3(double d) { float z; z = (float) d; return z; } float func4(int i) { float z; z = (float) i; return z; }";
+    std::string input = "int func(char c) { int z; z = (int) c; return z; }";
     std::string errorMessage;
     Parser parser(input);
     auto compUnitPtr = parser.parseCompilationUnit(&errorMessage);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -25,8 +25,7 @@ int main()
     // std::string input = "struct Vec2 { int x; int y; }; struct Vec3 { struct Vec2 v2; int z; }; int main() { struct Vec3 v3; v3.v2.x = 10; v3.v2.y = 12; v3.z = 20; int result; result = v3.v2.x + v3.v2.y + v3.z; return result; }";
     // std::string input = "enum A { X, Y }; int main() { int z; z = (int) Y; return z; }";
     // std::string input = "enum A { X, Y }; int main() { enum A a; a = Y; return (int) a; }";
-    // std::string input = "int func(char c) { int z; z = (int) c; return z; } double func2(float f) { double z; z = (double) f; return z; } float func3(double d) { float z; z = (float) d; return z; } float func4(int i) { float z; z = (float) i; return z; }";
-    std::string input = "int func(char c) { int z; z = (int) c; return z; }";
+    std::string input = "int func(char c) { int z; z = (int) c; return z; } double func2(float f) { double z; z = (double) f; return z; } float func3(double d) { float z; z = (float) d; return z; } float func4(int i) { float z; z = (float) i; return z; } int func5(int c) { int z; z = (int) c; return z; }";
     std::string errorMessage;
     Parser parser(input);
     auto compUnitPtr = parser.parseCompilationUnit(&errorMessage);

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -335,6 +335,24 @@ namespace cmm
         return std::nullopt;
     }
 
+    const char* toString(const EnumCastType type) CMM_NOEXCEPT
+    {
+        switch (type)
+        {
+        case EnumCastType::NOP:
+            return "NOP";
+        case EnumCastType::NARROWING:
+            return "NARROWING";
+        case EnumCastType::WIDENING:
+            return "WIDENING";
+        default:
+            return nullptr;
+        }
+
+        // Should be unreachable.
+        return nullptr;
+    }
+
     std::optional<EnumFieldAccessType> isEnumFieldAccessType(const Token& token) CMM_NOEXCEPT
     {
         if (token.isCharSymbol() && token.asCharSymbol() == CHAR_PERIOD)

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -221,6 +221,7 @@ namespace cmm
         return promoOrTruncateLookup(from, to, promoMap);
     }
 
+    [[deprecated("OBE")]]
     std::optional<CType> canTruncate(const CType& from, const CType& to)
     {
         static bool init = false;

--- a/src/VariableNode.cpp
+++ b/src/VariableNode.cpp
@@ -5,17 +5,18 @@
  * @version 2022-06-25
  */
 
+#include "cmm/Types.h"
 #include <cmm/VariableNode.h>
 
 namespace cmm
 {
     VariableNode::VariableNode(const Location& location, const std::string& name) :
-        ExpressionNode(EnumNodeType::VARIABLE, location), name(name)
+        ExpressionNode(EnumNodeType::VARIABLE, location), name(name), locality(EnumLocality::GLOBAL)
     {
     }
 
     VariableNode::VariableNode(const Location& location, std::string&& name) CMM_NOEXCEPT :
-        ExpressionNode(EnumNodeType::VARIABLE, location), name(std::move(name))
+        ExpressionNode(EnumNodeType::VARIABLE, location), name(std::move(name)), locality(EnumLocality::GLOBAL)
     {
     }
 
@@ -27,6 +28,16 @@ namespace cmm
     const std::string& VariableNode::getName() const CMM_NOEXCEPT
     {
         return name;
+    }
+
+    EnumLocality VariableNode::getLocality() const CMM_NOEXCEPT
+    {
+        return locality;
+    }
+
+    void VariableNode::setLocality(const EnumLocality locality) CMM_NOEXCEPT
+    {
+        this->locality = locality;
     }
 
     VisitorResult VariableNode::accept(Visitor* visitor) /* override */

--- a/src/VariableNode.cpp
+++ b/src/VariableNode.cpp
@@ -5,7 +5,6 @@
  * @version 2022-06-25
  */
 
-#include "cmm/Types.h"
 #include <cmm/VariableNode.h>
 
 namespace cmm

--- a/src/platform/PlatformLLVM.cpp
+++ b/src/platform/PlatformLLVM.cpp
@@ -6,6 +6,8 @@
  */
 
 // Our includes
+#include <cmm/Types.h>
+#include <cmm/visit/Visitor.h>
 #include <cmm/platform/PlatformLLVM.h>
 #include <cmm/NodeList.h>
 #include <cmm/Reporter.h>
@@ -282,17 +284,28 @@ namespace cmm
 
         // TODO (Nick): Rewrite this section to see if we actually need to cast,
         // zext, ztrunc (and float variants) here instead of blindly casting...
-        if ((fromCType.isInt() && toCType.type == EnumCType::ENUM) ||
-            (fromCType.type == EnumCType::ENUM && toCType.isInt()))
+        if (node.getCastType() == EnumCastType::NOP ||
+           (fromCType.isInt() && toCType.type == EnumCType::ENUM) ||
+           (fromCType.type == EnumCType::ENUM && toCType.isInt()))
         {
             return std::move(expr);
         }
 
         static auto& reporter = Reporter::instance();
+
+        /**
+         * This function facilitates the prefix or suffic to an LLVM cast.
+         *
+         * @param datatype the type to interpret.
+         * @return std::string.
+         */
         static auto datatypeToStr = [](const CType& datatype) -> std::string
         {
             if (datatype.isFloatingPoint())
+            {
                 return "fp";
+            }
+
             else if (datatype.isInt())
             {
                 // TODO: When we support unsigned types, make this dynamic:
@@ -303,14 +316,45 @@ namespace cmm
             std::ostringstream os;
             os << "unexpected CType (see compiler source code at " << __FILE__ << ": " << __LINE__ << ")";
             reporter.bug(os.str(), Location(0, 0), true);
-            return "\0";
+            return "";
         };
 
-        encoder->printIndent();
         auto& os = encoder->getOStream();
         auto temp = encoder->getTemp();
-        os << temp << " = " << datatypeToStr(fromCType) << "to" << datatypeToStr(toCType)
-           << " " << resolveDatatype(fromCType) << " " << *expr.result.str << " to " << resolveDatatype(toCType);
+
+        if (!fromCType.isPointerType() && !toCType.isPointerType() &&
+            (fromCType.isFloatingPoint() ^ toCType.isFloatingPoint()))
+        {
+            encoder->printIndent();
+            auto temp = encoder->getTemp();
+            os << temp << " = " << datatypeToStr(fromCType) << "to" << datatypeToStr(toCType)
+               << ' ' << resolveDatatype(fromCType) << ' ' << *expr.result.str << " to " << resolveDatatype(toCType);
+            encoder->emitNewline();
+
+            return VisitorResult(new std::string(std::move(temp)), true);
+        }
+
+        encoder->printIndent();
+        os << temp << " = " << (toCType.isFloatingPoint() ? "fp" : "z");
+
+        switch (node.getCastType())
+        {
+        case EnumCastType::NARROWING:
+            os << "trunc";
+            break;
+        case EnumCastType::WIDENING:
+            os << "ext";
+            break;
+        default:
+        {
+            std::ostringstream os;
+            os << "unexpected EnumCastType::NOP (see compiler source code at " << __FILE__ << ": " << __LINE__ << ")";
+            reporter.bug(os.str(), node.getLocation(), true);
+            return VisitorResult();
+        }
+        }
+
+        os << ' ' << resolveDatatype(fromCType) << ' ' << *expr.result.str << " to " << resolveDatatype(toCType);
         encoder->emitNewline();
 
         return VisitorResult(new std::string(std::move(temp)), true);

--- a/src/platform/PlatformLLVM.cpp
+++ b/src/platform/PlatformLLVM.cpp
@@ -282,11 +282,9 @@ namespace cmm
         const auto& fromCType = node.getExpression()->getDatatype();
         const auto& toCType = node.getDatatype();
 
-        // TODO (Nick): Rewrite this section to see if we actually need to cast,
-        // zext, ztrunc (and float variants) here instead of blindly casting...
-        if (node.getCastType() == EnumCastType::NOP ||
-           (fromCType.isInt() && toCType.type == EnumCType::ENUM) ||
-           (fromCType.type == EnumCType::ENUM && toCType.isInt()))
+        // If the cast gets NOP'd, do nothing but return the same expression we
+        // were given as the actual result.
+        if (node.getCastType() == EnumCastType::NOP)
         {
             return std::move(expr);
         }

--- a/src/platform/PlatformLLVM.cpp
+++ b/src/platform/PlatformLLVM.cpp
@@ -280,6 +280,8 @@ namespace cmm
         const auto& fromCType = node.getExpression()->getDatatype();
         const auto& toCType = node.getDatatype();
 
+        // TODO (Nick): Rewrite this section to see if we actually need to cast,
+        // zext, ztrunc (and float variants) here instead of blindly casting...
         if ((fromCType.isInt() && toCType.type == EnumCType::ENUM) ||
             (fromCType.type == EnumCType::ENUM && toCType.isInt()))
         {

--- a/src/visit/Analyzer.cpp
+++ b/src/visit/Analyzer.cpp
@@ -6,6 +6,7 @@
  */
 
 // Our includes
+#include <cmm/Types.h>
 #include <cmm/visit/Analyzer.h>
 #include <cmm/EnumTable.h>
 #include <cmm/NodeList.h>
@@ -305,11 +306,13 @@ namespace cmm
         {
             if (canPromote(from, to))
             {
-                // Note: Intentionally do nothing (no need to warn).
+                node.setCastType(EnumCastType::WIDENING);
             }
 
             else if (canTruncate(from, to))
             {
+                node.setCastType(EnumCastType::NARROWING);
+
                 // TODO: Consider conditionally reporting this, such as if the user
                 // passes a '-Wall' like flag.
                 std::ostringstream builder;
@@ -325,6 +328,8 @@ namespace cmm
 
         else if (from.pointers == to.pointers)
         {
+            node.setCastType(EnumCastType::NOP);
+
             // TODO: Consider conditionally reporting this, such as if the user
             // passes a '-Wall' like flag.
             std::ostringstream builder;

--- a/src/visit/Analyzer.cpp
+++ b/src/visit/Analyzer.cpp
@@ -308,7 +308,13 @@ namespace cmm
         const auto& from = expression->getDatatype();
         const auto& to = node.getDatatype();
 
-        if (from.pointers == 0 && from.pointers == to.pointers)
+        // Types are already the same. No-op the redundant cast.
+        if (from == to)
+        {
+            node.setCastType(EnumCastType::NOP);
+        }
+
+        else if (from.pointers == 0 && from.pointers == to.pointers)
         {
             if (canPromote(from, to))
             {

--- a/src/visit/Dump.cpp
+++ b/src/visit/Dump.cpp
@@ -104,6 +104,9 @@ namespace cmm
         printNewLine();
 
         increaseIntentation();
+        printIndentation();
+        std::cout << "EnumCastType: " << toString(node.getCastType());
+        printNewLine();
 
         if (node.hasExpression())
         {

--- a/test/AnalyzerTest.cpp
+++ b/test/AnalyzerTest.cpp
@@ -347,7 +347,8 @@ TEST(AnalyzerTest, AnalyzerExplicitDowncastLongToIntWarning)
 
     Analyzer analyzer;
     analyzer.visit(*compUnitPtr);
-    ASSERT_EQ(reporter.getWarningCount(), 1);
+    // ASSERT_EQ(reporter.getWarningCount(), 1);
+    ASSERT_GT(reporter.getWarningCount(), 0);
     ASSERT_EQ(reporter.getErrorCount(), 0);
 }
 
@@ -584,6 +585,24 @@ TEST(AnalyzerTest, AnalyzerImplicitCastIntPointerAddIntPointerError)
     analyzer.visit(*compUnitPtr);
     ASSERT_EQ(reporter.getWarningCount(), 0);
     ASSERT_GT(reporter.getErrorCount(), 0);
+}
+
+TEST(AnalyzerTest, AnalyzerUnnecessaryExplicitCastValid)
+{
+    reporter.reset();
+
+    const std::string input = "int main() { int z; z = (int) 5; return z; }";
+    Parser parser(input);
+    std::string errorMessage;
+    auto compUnitPtr = parser.parseCompilationUnit(&errorMessage);
+
+    ASSERT_TRUE(errorMessage.empty());
+    ASSERT_NE(compUnitPtr, nullptr);
+
+    Analyzer analyzer;
+    analyzer.visit(*compUnitPtr);
+    ASSERT_EQ(reporter.getWarningCount(), 0);
+    ASSERT_EQ(reporter.getErrorCount(), 0);
 }
 
 TEST(AnalyzerTest, AnalyzerParenExpressionNode)

--- a/test/AnalyzerTest.cpp
+++ b/test/AnalyzerTest.cpp
@@ -347,8 +347,7 @@ TEST(AnalyzerTest, AnalyzerExplicitDowncastLongToIntWarning)
 
     Analyzer analyzer;
     analyzer.visit(*compUnitPtr);
-    // ASSERT_EQ(reporter.getWarningCount(), 1);
-    ASSERT_GT(reporter.getWarningCount(), 0);
+    ASSERT_EQ(reporter.getWarningCount(), 2);
     ASSERT_EQ(reporter.getErrorCount(), 0);
 }
 
@@ -356,7 +355,6 @@ TEST(AnalyzerTest, AnalyzerExplicitDowncastIntToLongNoWarning)
 {
     reporter.reset();
 
-    // Weird code, but perfectly valid.
     const std::string input = "int x; x = 42; long y; y = (long) x;";
     Parser parser(input);
     std::string errorMessage;


### PR DESCRIPTION
This PR resolves the problem described in issue #76.  While working on the issue, I noticed a few other casts were in properly being handled.  For example, downcasting/narrowing from int to char should emit ztrunc instruction (LLVM) and inversely emit a zext instruction (LLVM) when upcasting/widening.