### PR TITLE
PR to Resolve issue #83

### DIFF
--- a/src/visit/Encode.cpp
+++ b/src/visit/Encode.cpp
@@ -70,7 +70,7 @@ namespace cmm
         auto visitorResult = expression->accept(this);
         auto optVisitorResult = platform->emit(this, node, visitorResult);
 
-        return std::move(*optVisitorResult);
+        return optVisitorResult.has_value() ? std::move(*optVisitorResult) : VisitorResult();
     }
 
     VisitorResult Encode::visit(BinOpNode& node)


### PR DESCRIPTION
In brief, an incorrect std::move on an optional VariableResult. On PlatformLLVM, emit on an ArgNode would always produce an std::nullopt.  For some reason this issue was only apparent until the last commit merged to main...